### PR TITLE
Add flake5 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     zip_safe=False,
     entry_points={
         'flake8.extension': [
-            'flake8_pytest = flake8_pytest:PytestAssertChecker',
+            'T = flake8_pytest:PytestAssertChecker',
         ],
     },
     install_requires=install_requires,


### PR DESCRIPTION
Flake8 now enforces the plugin code using the following regexp `^[A-Z]{1,3}[0-9]{0,3}$`. 

This PR fixes the following issue when trying to use flake8 v5:
```
There was a critical error during execution of Flake8:
plugin code for `flake8-pytest[flake8_pytest]` does not match ^[A-Z]{1,3}[0-9]{0,3}$
make: *** [Makefile:13: lint] Error 1
```

I copied the fix from a different flake8 plugin PR here: https://github.com/globality-corp/flake8-logging-format/pull/33

flake5 context:
* https://github.com/PyCQA/flake8/issues/1568
* https://github.com/PyCQA/flake8/issues/325